### PR TITLE
locking requirements for kombu to align with celery compat, ver bump

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -56,8 +56,8 @@ configuration = instrument_server.UploaderConfiguration()
 
 # development VERSION
 VERSION = {
-    'version_string': '2.2.11',
-    'last_updated': datetime.datetime.strptime('12.21.17', '%m.%d.%y')
+    'version_string': '2.2.12',
+    'last_updated': datetime.datetime.strptime('05.29.18', '%m.%d.%y')
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 celery==4.0.2
 pysqlite
 gunicorn~=19.3
+kombu<4.1


### PR DESCRIPTION
Kombu wanted to upgrade to 4.2.0 which breaks our implementation of celery <4.1